### PR TITLE
Pass groups as features and add support for using SKlearns CV utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,157 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+

--- a/example/xgbranker_cv_example.py
+++ b/example/xgbranker_cv_example.py
@@ -43,13 +43,14 @@ grid_search = GridSearchCV(
     },
     cv=GroupKFold(3),
     scoring=_RankingScorer(ndcg(3)),
-    verbose=100
+    verbose=100,
+    n_jobs=4
 )
 
 
+if __name__ == '__main__':
+    grid_search.fit(X, y, groups=X_groups)
 
-grid_search.fit(X, y, groups=X_groups)
-
-print("Cross validation results:")
-print(grid_search.cv_results_)
+    print("Cross validation results:")
+    print(grid_search.cv_results_)
 

--- a/example/xgbranker_cv_example.py
+++ b/example/xgbranker_cv_example.py
@@ -1,0 +1,55 @@
+"""
+Example on how to use Sklearn's Cross Validation utilities
+together with the XGBoost extension. This example fits a
+lambdaMART model on a generated dataset and then applies
+cross validation to find the optimal parameters.
+"""
+
+import numpy as np
+from xgboostextension import XGBRanker
+from xgboostextension.scorer import _RankingScorer
+from xgboostextension.scorer.metrics import ndcg
+from sklearn.model_selection import GridSearchCV, GroupKFold
+
+# Parameters for the samples being generated
+CASE_NUM = 5000
+GROUPS_NUM = 200
+N_FEATURES=40
+
+if CASE_NUM % GROUPS_NUM != 0:
+    raise ValueError('Cases should be splittable into equal groups.')
+
+
+# Generate some sample data to illustrate ranking
+X_features = np.random.rand(CASE_NUM, N_FEATURES)
+y = np.random.rand(CASE_NUM)
+X_groups = np.arange(0, GROUPS_NUM).repeat(CASE_NUM/GROUPS_NUM)
+
+
+# Append the group labels as a first axis to the features matrix
+# this is how the algorithm can distinguish between the different
+# groups
+X = np.concatenate([X_groups[:,None], X_features], axis=1)
+
+
+# objective = rank:pairwise(default).
+# Although rank:ndcg is also available,  rank:ndcg(listwise) is much worse than pairwise.
+ranker = XGBRanker(n_estimators=1, max_depth=3, learning_rate=0.1)
+grid_search = GridSearchCV(
+    ranker,
+    {
+        'n_estimators': [1, 10, 50],
+        'max_depth': [1,3,10]
+    },
+    cv=GroupKFold(3),
+    scoring=_RankingScorer(ndcg(3)),
+    verbose=100
+)
+
+
+
+grid_search.fit(X, y, groups=X_groups)
+
+print("Cross validation results:")
+print(grid_search.cv_results_)
+

--- a/example/xgbranker_example.py
+++ b/example/xgbranker_example.py
@@ -1,19 +1,34 @@
 import numpy as np
 from xgboostextension import XGBRanker
 
-case_num = 20
-X = np.random.rand(case_num, 4)
-y = np.random.randint(5, size=case_num)
-print("X="+str(X))
+CASE_NUM = 20
+GROUPS_NUM = 4
+
+if CASE_NUM % GROUPS_NUM != 0:
+    raise ValueError('Cases should be splittable into equal groups.')
+
+# Generate some sample data to illustrate ranking
+X_features = np.random.rand(CASE_NUM, 4)
+y = np.random.randint(5, size=CASE_NUM)
+X_groups = np.arange(0, GROUPS_NUM).repeat(CASE_NUM/GROUPS_NUM)
+
+print("X="+str(X_features))
 print("y="+str(y))
+
+# Append the group labels as a first axis to the features matrix
+# this is how the algorithm can distinguish between the different
+# groups
+X = np.concatenate([X_groups[:,None], X_features], axis=1)
+
 
 # objective = rank:pairwise(default).
 # Although rank:ndcg is also available,  rank:ndcg(listwise) is much worse than pairwise.
 # So ojective is always rank:pairwise whatever you write. 
-ranker = XGBRanker(n_estimators=150, learning_rate=0.1, subsample=0.9)#, objective='rank:pairwise')
-# 100 samples, 4 groups, 25/group, predicted_values can be used to sort x in their own group
-ranker.fit(X, y, [5, 5, 5, 5], eval_metric=['ndcg', 'map@5-'])
-y_predict = ranker.predict(X, [5, 5, 5, 5])
+ranker = XGBRanker(n_estimators=150, learning_rate=0.1, subsample=0.9)
+
+
+ranker.fit(X, y, eval_metric=['ndcg', 'map@5-'])
+y_predict = ranker.predict(X)
 
 print("predict:"+str(y_predict))
 print("type(y_predict):"+str(type(y_predict)))

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,9 @@ setup(
     license='Apache 2.0',
     description='XGBoost Extension for Easy Ranking & TreeFeature.',
     install_requires=[
-        'xgboost>=0.7'
+        'xgboost>=0.7',
+        'scikit-learn>=0.19.0',
+        'numpy>=1.14.0'
     ],
     setup_requires=[]
 )

--- a/xgboostextension/scorer/__init__.py
+++ b/xgboostextension/scorer/__init__.py
@@ -1,0 +1,39 @@
+from sklearn.metrics.scorer import _BaseScorer
+from xgboostextension.xgbranker import XGBRanker, _preprare_data_in_groups
+from xgboostextension.scorer.util import _make_grouped_metric
+
+
+class _RankingScorer(_BaseScorer):
+    def __init__(self, score_func, sign=1):
+        """
+        Base class for applying scoring functions to ranking problems.
+        This class transforms a ranking metric into a scoring function
+        that can be applied to estimations that take a group indicator in
+        their first column.
+
+        Parameters
+        ----------
+        """
+        if not score_func.__module__ == 'xgboostextension.scorer.metrics':
+            raise ValueError(
+                'Only score functions included with this package are supported'
+            )
+
+        super(_RankingScorer, self).__init__(
+            _make_grouped_metric(score_func),
+            sign,
+            None
+        )
+
+    def __call__(self, estimator, X, y, sample_weight=None):
+        if not isinstance(estimator, XGBRanker):
+            raise NotImplementedError((
+                'Currently only scoring for the'
+                'XGBRanker model is supported.'
+            ))
+
+        sizes, _, y_sorted, _ = _preprare_data_in_groups(X, y)
+
+        y_predicted = estimator.predict(X)
+
+        return self._sign * self._score_func(sizes, y_sorted, y_predicted)

--- a/xgboostextension/scorer/metrics.py
+++ b/xgboostextension/scorer/metrics.py
@@ -1,0 +1,75 @@
+import numpy as np
+
+
+def dcg_at_k(r, k, method=0):
+    """
+    Basic implementation of the DCG metric,
+    credits to: https://gist.github.com/bwhite/3726239
+
+    Parameters
+    ----------
+    r : (1d-array) Relavances, sorted as in the result (i.e. to predicted rank)
+
+    k : (int) evaluate up till this position
+
+    method : (int, 0 or 1) Weights to use when calculating relevance
+
+    Returns
+    -------
+    dcg (float) : the calculated dcg value
+    """
+
+    # Pad r if necessary
+    if r.shape[0] < k:
+        padding = k - r.shape[0]
+        r = np.pad(r, (0, padding), 'constant', constant_values=0)
+
+    if r.size:
+        if method == 0:
+            return r[0] + np.sum(r[1:] / np.log2(np.arange(2, r.size + 1)))
+        elif method == 1:
+            return np.sum(r / np.log2(np.arange(2, r.size + 2)))
+        else:
+            raise ValueError('method must be 0 or 1.')
+    return 0.
+
+
+def ndcg_at_k(r, k, method=0):
+    """
+    Basic implementation of the nDCG metric,
+    credits to: https://gist.github.com/bwhite/3726239
+
+    Parameters
+    ----------
+    r : (1d-array) Relavances, sorted as in the result (i.e. to predicted rank)
+
+    k : (int) evaluate up till this position
+
+    method : (int, 0 or 1) Weights to use when calculating relevance
+
+    Returns
+    -------
+    ndcg (float) : the calculated ndcg value
+    """
+    dcg_max = dcg_at_k(np.sort(r)[::-1], k, method)
+    if not dcg_max:
+        return 0.
+    return dcg_at_k(r, k, method) / dcg_max
+
+
+def ndcg(k):
+    """
+    Wrapper to make a closure to transform ndcg_at_k into a metric
+
+    Parameters
+    ----------
+    k : (int) the order up to which to evaluate ndcg
+
+    Returns
+    -------
+    ndcg_at_k : (callable) metric that calculated the ndcg up till k
+    """
+    def inner(r):
+        return ndcg_at_k(r, k)
+
+    return inner

--- a/xgboostextension/scorer/metrics.py
+++ b/xgboostextension/scorer/metrics.py
@@ -57,19 +57,18 @@ def ndcg_at_k(r, k, method=0):
     return dcg_at_k(r, k, method) / dcg_max
 
 
-def ndcg(k):
-    """
-    Wrapper to make a closure to transform ndcg_at_k into a metric
+class ndcg:
+    def __init__(self, k):
+        """
+        Simple wrapper class to make a true metric from ndcg_at_k,
+        i.e. a callable only accepting one argument. A simple closure
+        cannot be used for this purpose since that cannot be pickled.
 
-    Parameters
-    ----------
-    k : (int) the order up to which to evaluate ndcg
+        Parameters
+        ----------
+        k : (int) order of ndcg to use
+        """
+        self.k = k
 
-    Returns
-    -------
-    ndcg_at_k : (callable) metric that calculated the ndcg up till k
-    """
-    def inner(r):
-        return ndcg_at_k(r, k)
-
-    return inner
+    def __call__(self, r):
+        ndcg_at_k(r, self.k)

--- a/xgboostextension/scorer/util.py
+++ b/xgboostextension/scorer/util.py
@@ -1,35 +1,19 @@
 import numpy as np
 
 
-def _make_grouped_metric(metric):
-    """
-    Wrapper to turn a single metric into a metric
-    that is applied per group
-
-    Parameters
-    ----------
-    metric : (callable) The metric that should be applied per group
-
-    Returns
-    -------
-    apply_batch : (callable) Function that applies the metric per group
-        and averages the result
+class _make_grouped_metric:
+    def __init__(self, metric):
+        """
+        Wrapper to turn a single metric into a metric
+        that can be applied per group.
 
         Parameters
         ----------
-        sizes : (1d-array) the sizes of each group
+        metric : (callable) The metric that should be applied per group
+        """
+        self._metric = metric
 
-        y_sorted : (1d-array) true target, sorted by group
-
-        y_predicted : (1d-array) predicted target, sorted by group
-
-        Returns
-        -------
-        result : (float) the value of the metric averaged over the groups
-
-    """
-    def apply_batch(sizes, y_sorted, y_predicted):
-        nonlocal metric
+    def __call__(self, sizes, y_sorted, y_predicted):
         split_indices = np.cumsum(sizes)[:-1]
 
         # Split into a different set for each query
@@ -43,9 +27,7 @@ def _make_grouped_metric(metric):
                 zip(y_sorted_split, y_predicted_split)
         ):
             indices = np.argsort(pred)[::-1]
-            results[i] = metric(r[indices])
+            results[i] = self._metric(r[indices])
 
         # Return the average over all statistics
         return results.mean()
-
-    return apply_batch

--- a/xgboostextension/scorer/util.py
+++ b/xgboostextension/scorer/util.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+
+def _make_grouped_metric(metric):
+    """
+    Wrapper to turn a single metric into a metric
+    that is applied per group
+
+    Parameters
+    ----------
+    metric : (callable) The metric that should be applied per group
+
+    Returns
+    -------
+    apply_batch : (callable) Function that applies the metric per group
+        and averages the result
+
+        Parameters
+        ----------
+        sizes : (1d-array) the sizes of each group
+
+        y_sorted : (1d-array) true target, sorted by group
+
+        y_predicted : (1d-array) predicted target, sorted by group
+
+        Returns
+        -------
+        result : (float) the value of the metric averaged over the groups
+
+    """
+    def apply_batch(sizes, y_sorted, y_predicted):
+        nonlocal metric
+        split_indices = np.cumsum(sizes)[:-1]
+
+        # Split into a different set for each query
+        y_sorted_split = np.split(y_sorted, split_indices)
+        y_predicted_split = np.split(y_predicted, split_indices)
+
+        # Go through each query and calculate the statistic's
+        # value
+        results = np.zeros(sizes.shape[0])
+        for i, (r, pred) in enumerate(
+                zip(y_sorted_split, y_predicted_split)
+        ):
+            indices = np.argsort(pred)[::-1]
+            results[i] = metric(r[indices])
+
+        # Return the average over all statistics
+        return results.mean()
+
+    return apply_batch

--- a/xgboostextension/util.py
+++ b/xgboostextension/util.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy import sparse
 
 
 def _preprare_data_in_groups(X, y=None, sample_weights=None):
@@ -24,7 +25,11 @@ def _preprare_data_in_groups(X, y=None, sample_weights=None):
 
     sample_weights: (None or 1d-array) sample weights sorted per group
     """
-    group_labels = X[:,0]
+    if sparse.issparse(X):
+        group_labels = X.getcol(0).toarray()[:,0]
+    else:
+        group_labels = X[:,0]
+
     group_indices = group_labels.argsort()
 
     group_labels = group_labels[group_indices]

--- a/xgboostextension/util.py
+++ b/xgboostextension/util.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+
+def _preprare_data_in_groups(X, y=None, sample_weights=None):
+    """
+    Takes the first column of the feature Matrix X given and
+    transforms the data into groups accordingly.
+
+    Parameters
+    ----------
+    X : (2d-array like) Feature matrix with the first column the group label
+
+    y : (optional, 1d-array like) target values
+
+    sample_weights : (optional, 1d-array like) sample weights
+
+    Returns
+    -------
+    sizes: (1d-array) group sizes
+
+    X_features : (2d-array) features sorted per group
+
+    y : (None or 1d-array) Target sorted per group
+
+    sample_weights: (None or 1d-array) sample weights sorted per group
+    """
+    group_labels = X[:,0]
+    group_indices = group_labels.argsort()
+
+    group_labels = group_labels[group_indices]
+    _, sizes = np.unique(group_labels, return_counts=True)
+    X = X[group_indices, 1:]
+
+    if y is not None:
+        y = y[group_indices]
+
+    if sample_weights is not None:
+        sample_weights = sample_weights[group_indices]
+
+    return sizes, X, y, sample_weights

--- a/xgboostextension/xgbranker.py
+++ b/xgboostextension/xgbranker.py
@@ -4,6 +4,45 @@ from xgboost import DMatrix, train
 from xgboost.sklearn import _objective_decorator
 from sklearn.utils import check_X_y, check_array
 
+def _preprare_data_in_groups(X, y=None, sample_weights=None):
+    """
+    Takes the first column of the feature Matrix X given and
+    transforms the data into groups accordingly.
+
+    Parameters
+    ----------
+    X : (2d-array like) Feature matrix with the first column the group label
+
+    y : (optional, 1d-array like) target values
+
+    sample_weights : (optional, 1d-array like) sample weights
+
+    Returns
+    -------
+    sizes: (1d-array) group sizes
+
+    X_features : (2d-array) features sorted per group
+
+    y : (None or 1d-array) Target sorted per group
+
+    sample_weights: (None or 1d-array) sample weights sorted per group
+    """
+    group_labels = X[:,0]
+    group_indices = group_labels.argsort()
+
+    group_labels = group_labels[group_indices]
+    _, sizes = np.unique(group_labels, return_counts=True)
+    X = X[group_indices, 1:]
+
+    if y is not None:
+        y = y[group_indices]
+
+    if sample_weights is not None:
+        sample_weights = sample_weights[group_indices]
+
+    return sizes, X, y, sample_weights
+
+
 
 class XGBRanker(XGBModel):
     __doc__ = """Implementation of sklearn API for XGBoost Ranking
@@ -67,13 +106,7 @@ class XGBRanker(XGBModel):
 
         X, y = check_X_y(X, y, accept_sparse=False, y_numeric=True)
 
-        group_labels = X[:,0]
-        group_indices = group_labels.argsort()
-
-        group_labels = group_labels[group_indices]
-        _, sizes = np.unique(group_labels, return_counts=True)
-        X = X[group_indices, 1:]
-        y = y[group_indices]
+        sizes, X, y, _ = _preprare_data_in_groups(X, y)
 
         params = self.get_xgb_params()
 

--- a/xgboostextension/xgbranker.py
+++ b/xgboostextension/xgbranker.py
@@ -1,6 +1,9 @@
-import xgboost
+import numpy as np
 from xgboost import XGBModel
 from xgboost import DMatrix, train
+from xgboost.sklearn import _objective_decorator
+from sklearn.utils import check_X_y, check_array
+
 
 class XGBRanker(XGBModel):
     __doc__ = """Implementation of sklearn API for XGBoost Ranking
@@ -20,20 +23,17 @@ class XGBRanker(XGBModel):
                                         reg_alpha, reg_lambda, scale_pos_weight,
                                         base_score, random_state, seed, missing)
 
-
-    def fit(self, X, y, group=None, eval_metric=None, sample_weight=None,
-            early_stopping_rounds=None, verbose=True):
+    def fit(self, X, y, sample_weight=None, eval_set=None, eval_metric=None,
+            early_stopping_rounds=None, verbose=True, xgb_model=None):
         """
         Fit the gradient boosting model
 
         Parameters
         ----------
         X : array_like
-            Feature matrix
+            Feature matrix with the first feature containing a group indicator
         y : array_like
             Labels
-        group : list, optional
-            Group number list. All X and y will be taken as single group when group is not provided. All ranking is valid only in their own group.
         sample_weight : array_like
             instance weights
         eval_set : list, optional
@@ -64,18 +64,26 @@ class XGBRanker(XGBModel):
             file name of stored xgb model or 'Booster' instance Xgb model to be
             loaded before training (allows training continuation).
         """
-        if group is None:
-            group = [X.shape[0]]
-        
+
+        X, y = check_X_y(X, y, accept_sparse=False, y_numeric=True)
+
+        group_labels = X[:,0]
+        group_indices = group_labels.argsort()
+
+        group_labels = group_labels[group_indices]
+        _, sizes = np.unique(group_labels, return_counts=True)
+        X = X[group_indices, 1:]
+        y = y[group_indices]
+
         params = self.get_xgb_params()
- 
+
         if callable(self.objective):
             obj = _objective_decorator(self.objective)
-            # Use default value. Is it really not used ?
-            xgb_options["objective"] = "rank:pairwise"
+            # Dummy, Not used when custom objective is given
+            params["objective"] = "binary:logistic"
         else:
             obj = None
-        
+
         evals_result = {}
         feval = eval_metric if callable(eval_metric) else None
         if eval_metric is not None:
@@ -90,18 +98,15 @@ class XGBRanker(XGBModel):
         else:
             train_dmatrix = DMatrix(X, label=y,
                                     missing=self.missing)
-        train_dmatrix.set_group(group)
-        
-        self.objective = params["objective"]
+
+        train_dmatrix.set_group(sizes)
 
         self._Booster = train(params, train_dmatrix, 
                               self.n_estimators,
                               early_stopping_rounds=early_stopping_rounds,
                               evals_result=evals_result, obj=obj, feval=feval,
-                              verbose_eval=verbose,
-                              xgb_model=None)
+                              verbose_eval=verbose, xgb_model=xgb_model)
 
-        
         if evals_result:
             for val in evals_result.items():
                 evals_result_key = list(val[1].keys())[0]
@@ -115,11 +120,20 @@ class XGBRanker(XGBModel):
 
         return self
 
-    def predict(self, X, group=None, output_margin=False, ntree_limit=0):
-        if group == None:
-            group = [X.shape[0]]
+    def predict(self, X, output_margin=False, ntree_limit=0):
+        X = check_array(X, accept_sparse=False)
+
+        group_labels = X[:,0]
+        group_indices = group_labels.argsort()
+        X = X[group_indices, 1:]
+
+        # Rearrange the labels to be sure of the order and
+        # calculate the group sizes
+        group_labels = group_labels[group_indices]
+        _, sizes = np.unique(group_labels, return_counts=True)
+
         test_dmatrix = DMatrix(X, missing=self.missing)
-        test_dmatrix.set_group(group)
+        test_dmatrix.set_group(sizes)
         rank_values = self.get_booster().predict(test_dmatrix,
                                                  output_margin=output_margin,
                                                  ntree_limit=ntree_limit)

--- a/xgboostextension/xgbranker.py
+++ b/xgboostextension/xgbranker.py
@@ -116,16 +116,7 @@ class XGBRanker(XGBModel):
         return self
 
     def predict(self, X, output_margin=False, ntree_limit=0):
-        X = check_array(X, accept_sparse=False)
-
-        group_labels = X[:,0]
-        group_indices = group_labels.argsort()
-        X = X[group_indices, 1:]
-
-        # Rearrange the labels to be sure of the order and
-        # calculate the group sizes
-        group_labels = group_labels[group_indices]
-        _, sizes = np.unique(group_labels, return_counts=True)
+        sizes, X, _, _ = _preprare_data_in_groups(X)
 
         test_dmatrix = DMatrix(X, missing=self.missing)
         test_dmatrix.set_group(sizes)

--- a/xgboostextension/xgbranker.py
+++ b/xgboostextension/xgbranker.py
@@ -1,47 +1,9 @@
 import numpy as np
-from xgboost import XGBModel
-from xgboost import DMatrix, train
-from xgboost.sklearn import _objective_decorator
 from sklearn.utils import check_X_y, check_array
-
-def _preprare_data_in_groups(X, y=None, sample_weights=None):
-    """
-    Takes the first column of the feature Matrix X given and
-    transforms the data into groups accordingly.
-
-    Parameters
-    ----------
-    X : (2d-array like) Feature matrix with the first column the group label
-
-    y : (optional, 1d-array like) target values
-
-    sample_weights : (optional, 1d-array like) sample weights
-
-    Returns
-    -------
-    sizes: (1d-array) group sizes
-
-    X_features : (2d-array) features sorted per group
-
-    y : (None or 1d-array) Target sorted per group
-
-    sample_weights: (None or 1d-array) sample weights sorted per group
-    """
-    group_labels = X[:,0]
-    group_indices = group_labels.argsort()
-
-    group_labels = group_labels[group_indices]
-    _, sizes = np.unique(group_labels, return_counts=True)
-    X = X[group_indices, 1:]
-
-    if y is not None:
-        y = y[group_indices]
-
-    if sample_weights is not None:
-        sample_weights = sample_weights[group_indices]
-
-    return sizes, X, y, sample_weights
-
+from xgboost import DMatrix, train
+from xgboost import XGBModel
+from xgboost.sklearn import _objective_decorator
+from xgboostextension.util import _preprare_data_in_groups
 
 
 class XGBRanker(XGBModel):


### PR DESCRIPTION
Pull request that resolves #6

Group labels are now passed as a first column in the feature matrix to the estimator. The estimator strips this column, reorders the data and calculates the group sizes. Also this PR includes some ranking metrics that can be used to evaluate prediction quality (because SKlearns ndcg metric has been removed).

Feel free to squash my commits.